### PR TITLE
feat: enforce selectionSequence on Android (parity with iOS)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 2.0.4
+
+* 13th release of `interactive_3d`
+- Added `selectionSequence` enforcement on Android, matching the existing iOS behavior — taps that violate the configured order are rejected and emit a `selectionRejected` event.
+
+
 ## 2.0.3
 
 * 12th release of `interactive_3d`

--- a/android/src/main/kotlin/com/example/interactive_3d/Interactive3dPlugin.kt
+++ b/android/src/main/kotlin/com/example/interactive_3d/Interactive3dPlugin.kt
@@ -135,7 +135,8 @@ class Interactive3dPlugin : FlutterPlugin, MethodChannel.MethodCallHandler {
         patchColors = call.argument("patchColors"),
         enableCache = call.argument<Boolean>("enableCache") ?: false,
         cacheColor = call.argument("cacheColor"),
-        clearSelectionsOnHighlight = call.argument<Boolean>("clearSelectionsOnHighlight") ?: false
+        clearSelectionsOnHighlight = call.argument<Boolean>("clearSelectionsOnHighlight") ?: false,
+        selectionSequence = call.argument("selectionSequence")
       )
       result.success(null)
     } catch (e: Exception) {

--- a/android/src/main/kotlin/com/example/interactive_3d/Interactive3dTextureEntry.kt
+++ b/android/src/main/kotlin/com/example/interactive_3d/Interactive3dTextureEntry.kt
@@ -99,6 +99,7 @@ class Interactive3dTextureEntry(
             filamentRenderer = FilamentRenderer(context, currentWidth, currentHeight)
             filamentRenderer?.setSelectionListener { sendSelectionEvent(it) }
             filamentRenderer?.setCacheSelectionListener { sendCacheSelectionEvent(it) }
+            filamentRenderer?.setSelectionRejectedListener { sendSelectionRejectedEvent(it) }
         }
 
         filamentRenderer?.createSwapChain(producer.getSurface())
@@ -119,13 +120,14 @@ class Interactive3dTextureEntry(
         buffer: ByteBuffer, fileName: String, resources: Map<String, ByteArray>,
         preselectedEntities: List<String>?, selectionColor: List<Double>?,
         patchColors: List<Map<String, Any>>?, enableCache: Boolean, cacheColor: List<Double>?,
-        clearSelectionsOnHighlight: Boolean = false
+        clearSelectionsOnHighlight: Boolean = false,
+        selectionSequence: List<Map<String, Any>>? = null
     ) {
         val op = {
             filamentRenderer?.loadModel(
                 buffer, fileName, resources, preselectedEntities,
                 selectionColor, patchColors, enableCache, cacheColor,
-                clearSelectionsOnHighlight
+                clearSelectionsOnHighlight, selectionSequence
             )
         }
         if (filamentRenderer != null && surfaceProducer?.getSurface()?.isValid == true) {
@@ -186,6 +188,12 @@ class Interactive3dTextureEntry(
     private fun sendCacheSelectionEvent(entities: List<Map<String, Any>>) {
         mainHandler.post {
             eventSink?.success(mapOf("event" to "cacheSelectionChanged", "cachedEntities" to entities))
+        }
+    }
+
+    private fun sendSelectionRejectedEvent(name: String) {
+        mainHandler.post {
+            eventSink?.success(mapOf("event" to "selectionRejected", "name" to name))
         }
     }
 

--- a/android/src/main/kotlin/com/example/interactive_3d/renderer/FilamentRenderer.kt
+++ b/android/src/main/kotlin/com/example/interactive_3d/renderer/FilamentRenderer.kt
@@ -56,6 +56,10 @@ class FilamentRenderer(
     internal val environment = EnvironmentLoader()
     internal val modelLoader = ModelLoader()
     internal val selection = SelectionManager()
+    internal val sequenceValidator = SequenceValidator()
+
+    // Notified when a tap is rejected by sequence validation
+    private var onSelectionRejected: ((String) -> Unit)? = null
 
     // Device-adaptive settings
     private val deviceTier: DeviceCapability.Tier
@@ -245,7 +249,8 @@ class FilamentRenderer(
         patchColors: List<Map<String, Any>>?,
         enableCache: Boolean,
         cacheColor: List<Double>?,
-        clearSelectionsOnHighlight: Boolean = false
+        clearSelectionsOnHighlight: Boolean = false,
+        selectionSequence: List<Map<String, Any>>? = null
     ) {
         val eng = engine ?: return
         val scn = scene ?: return
@@ -262,6 +267,13 @@ class FilamentRenderer(
         selection.patchColors = patchColors
         selection.enableCache = enableCache
         selection.clearSelectionsOnHighlight = clearSelectionsOnHighlight
+
+        // Configure sequence validation (active whenever the list is non-empty)
+        if (selectionSequence != null) {
+            sequenceValidator.configure(selectionSequence)
+        } else {
+            sequenceValidator.reset()
+        }
 
         if (enableCache) {
             selection.cacheColor = cacheColor.toFloatArrayOrDefault(floatArrayOf(0.8f, 0.8f, 0.2f, 0.6f))
@@ -336,6 +348,19 @@ class FilamentRenderer(
             if (!isModelEntity) return@pick
 
             val eng = engine ?: return@pick
+
+            // Sequence validation — mirror iOS Interactive3dView.handleTap
+            val nodeName = asset.getName(entity)
+            if (nodeName != null) {
+                val selectedNames = selection.selectedEntities
+                    .mapNotNull { asset.getName(it) }
+                    .toSet()
+                if (!sequenceValidator.isTapAllowed(nodeName, selectedNames)) {
+                    onSelectionRejected?.invoke(nodeName)
+                    return@pick
+                }
+            }
+
             selection.handleTap(entity, asset, eng)
         }
     }
@@ -463,6 +488,10 @@ class FilamentRenderer(
         selection.onCacheSelectionChanged = listener
     }
 
+    fun setSelectionRejectedListener(listener: (String) -> Unit) {
+        onSelectionRejected = listener
+    }
+
     // -------------------------------------------------------------------------
     // Cleanup
     // -------------------------------------------------------------------------
@@ -473,6 +502,7 @@ class FilamentRenderer(
         val eng = engine ?: return
 
         selection.cleanup(eng)
+        sequenceValidator.reset()
         cameraController.cancelCallbacks()
         ioScope.cancel()
 

--- a/android/src/main/kotlin/com/example/interactive_3d/renderer/SequenceValidator.kt
+++ b/android/src/main/kotlin/com/example/interactive_3d/renderer/SequenceValidator.kt
@@ -1,0 +1,114 @@
+package com.example.interactive_3d.renderer
+
+/**
+ * Validates whether a tap on a named entity is allowed based on
+ * ordered selection rules.
+ *
+ * When the user provides selection sequence entries, taps are constrained
+ * so entities within a group can only be selected in the defined order.
+ * Bidirectional configs allow selection in either direction from the
+ * current position. Tied groups enforce matching indices across groups.
+ *
+ * Mirrors iOS SequenceValidator.swift behavior. Validation is active
+ * whenever [configs] is non-empty; nodes outside any configured group
+ * are always allowed.
+ */
+internal class SequenceValidator {
+
+    data class Config(
+        val group: String,
+        val order: List<String>,
+        val bidirectional: Boolean,
+        val tiedGroup: String?
+    )
+
+    var configs: List<Config> = emptyList()
+        private set
+
+    private val allowedNext = mutableMapOf<String, MutableSet<String>>()
+
+    /** Parses sequence configs from the Flutter method call arguments. */
+    fun configure(array: List<Map<String, Any>>) {
+        configs = array.mapNotNull { dict ->
+            val group = dict["group"] as? String ?: return@mapNotNull null
+            @Suppress("UNCHECKED_CAST")
+            val order = dict["order"] as? List<String> ?: return@mapNotNull null
+            val bidirectional = dict["bidirectional"] as? Boolean ?: return@mapNotNull null
+            Config(
+                group = group,
+                order = order,
+                bidirectional = bidirectional,
+                tiedGroup = dict["tiedGroup"] as? String
+            )
+        }
+        buildMaps()
+    }
+
+    /** Resets all sequence state. */
+    fun reset() {
+        configs = emptyList()
+        allowedNext.clear()
+    }
+
+    /**
+     * Returns true if [nodeName] is allowed to be tapped given the current
+     * set of [selectedNames].
+     *
+     * Rules:
+     * - Deselecting (tapping an already selected node) is always allowed.
+     * - Nodes not in any sequence are always allowed.
+     * - First pick in a group is free, unless a tied group has started
+     *   (then the matching index must be selected).
+     * - Subsequent picks must be adjacent via the forward (and optionally
+     *   backward) adjacency map.
+     */
+    fun isTapAllowed(nodeName: String, selectedNames: Set<String>): Boolean {
+        // Deselecting is always allowed
+        if (selectedNames.contains(nodeName)) return true
+
+        val config = configs.firstOrNull { it.order.contains(nodeName) }
+            ?: return true // not part of any sequence
+        val idx = config.order.indexOf(nodeName)
+
+        val selectedInGroup = selectedNames.filter { config.order.contains(it) }
+
+        var selectedInTied: List<String> = emptyList()
+        val tiedConfig = config.tiedGroup?.let { tiedName ->
+            configs.firstOrNull { it.group == tiedName }
+        }
+        if (tiedConfig != null) {
+            selectedInTied = selectedNames.filter { tiedConfig.order.contains(it) }
+        }
+
+        // Group hasn't started yet
+        if (selectedInGroup.isEmpty()) {
+            if (selectedInTied.isNotEmpty() && tiedConfig != null) {
+                val requiredNode = tiedConfig.order[idx]
+                return selectedInTied.contains(requiredNode)
+            }
+            return true
+        }
+
+        // Once started, only adjacent nodes are allowed
+        for (name in selectedInGroup) {
+            if (allowedNext[name]?.contains(nodeName) == true) return true
+        }
+
+        return false
+    }
+
+    private fun buildMaps() {
+        allowedNext.clear()
+        for (config in configs) {
+            val list = config.order
+            for (i in 0 until list.size - 1) {
+                val name = list[i]
+                val nextName = list[i + 1]
+                allowedNext.getOrPut(name) { mutableSetOf() }.add(nextName)
+                if (config.bidirectional) {
+                    allowedNext.getOrPut(nextName) { mutableSetOf() }.add(name)
+                }
+            }
+        }
+    }
+}

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -120,7 +120,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "2.0.3"
+    version: "2.0.4"
   leak_tracker:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: interactive_3d
 description: "A plugin to render interactive 3D model in .gLTF or .glb format using Filament on Android & GLTFSceneKit on iOS"
-version: 2.0.3
+version: 2.0.4
 
 license: MIT
 


### PR DESCRIPTION
Ports SequenceValidator to the Android renderer. Validates taps against the configured order before mutating selection state and emits a selectionRejected event on rejection — matching iOS behavior.